### PR TITLE
Replaces chalk with ansi-colors

### DIFF
--- a/index.js
+++ b/index.js
@@ -829,7 +829,7 @@ function showCommandHelp(command){
       var subcommand = command.commands[name];
 
       var line = {
-        name: chalk.green(name) + chalk.gray(
+        name: colors.green(name) + colors.gray(
           (subcommand.params ? ' ' + args(subcommand) : '')
           // (subcommand.hasOptions() ? ' [options]' : '')
         ),
@@ -866,7 +866,7 @@ function showCommandHelp(command){
             return m || (hasShortOptions ? '    ' : '');
           })
           .replace(/(^|\s)(-[^\s,]+)/ig, function(m, p, flag){
-            return p + chalk.yellow(flag);
+            return p + colors.yellow(flag);
           }),
         description: option.description
       };
@@ -889,19 +889,19 @@ function showCommandHelp(command){
   }
 
   var output = [];
-  var chalk = require('chalk');
+  var colors = require('ansi-colors');
 
-  chalk.enabled = module.exports.color && process.stdout.isTTY;
+  colors.enabled = module.exports.color && process.stdout.isTTY;
 
   if (command.description_)
     output.push(command.description_ + '\n');
 
   output.push(
     'Usage:\n\n  ' +
-      chalk.cyan(commandsPath ? commandsPath.join(' ') : command.name) +
-      (command.params ? ' ' + chalk.magenta(args(command)) : '') +
-      (command.hasOptions() ? ' [' + chalk.yellow('options') + ']' : '') +
-      (command.hasCommands() ? ' [' + chalk.green('command') + ']' : ''),
+      colors.cyan(commandsPath ? commandsPath.join(' ') : command.name) +
+      (command.params ? ' ' + colors.magenta(args(command)) : '') +
+      (command.hasOptions() ? ' [' + colors.yellow('options') + ']' : '') +
+      (command.hasCommands() ? ' [' + colors.green('command') + ']' : ''),
     commandsHelp() +
     optionsHelp()
   );

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">=0.10.0"
   },
   "dependencies": {
-    "chalk": "^1.1.3"
+    "ansi-colors": "^1.1.0"
   },
   "devDependencies": {
     "mocha": "^2.4.5"


### PR DESCRIPTION
Hi, this PR replaces chalk with [ansi-colors](https://github.com/doowb/ansi-colors).

ansi-colors has fewer dependencies (in v1.1.0) and zero dependencies in the latest versions. It's also more performant when loading and executing, which I think is important in a command line library.

I'm using v1.1.0 in this PR since it's compatible with older versions of node. If you decide to support newer versions, you can update to the latest version of ansi-colors which has even better performance.